### PR TITLE
Update build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,6 +11,7 @@ buildscript {
         playServicesVersion = "17+"
         firebaseMessagingVersion = "21.0.0"
         androidXCore = "1.6.0"
+        ndkVersion = "23.2.8568313"
     }
     repositories {
         google()


### PR DESCRIPTION
On Mar 20 2024 after enabling OTA, Editing roadside/android/build.gradle to add this as last line inside ext {....}: // NDK 23 has both M1 support and is side by side NDK version from AGP
	ndkVersion = "23.2.8568313"

	Just to avoid this error in native builder.
		2024-03-20T14:53:49.3462770Z > Task :app:stripAppstoreReleaseDebugSymbols FAILED
		2024-03-20T14:53:49.3573840Z WARNING: Support for ANDROID_NDK_HOME is deprecated and will be removed in the future. Use android.ndkVersion in build.gradle instead.
		2024-03-20T14:53:49.3675680Z Support for ANDROID_NDK_HOME is deprecated and will be removed in the future. Use android.ndkVersion in build.gradle instead.
		2024-03-20T14:53:51.8838060Z 
		2024-03-20T14:53:51.8838620Z FAILURE: Build failed with an exception.
		2024-03-20T14:53:51.8838790Z 
		2024-03-20T14:53:51.8838960Z * What went wrong:
		2024-03-20T14:53:51.8839510Z Execution failed for task ':app:stripAppstoreReleaseDebugSymbols'.
		2024-03-20T14:53:51.8839840Z > No version of NDK matched the requested version 23.2.8568313. Versions available locally: 24.0.8215888, 25.2.9519653, 25.2.9519653, 26.1.10909125
		2024-03-20T14:53:51.8840020Z 
		2024-03-20T14:53:51.8840170Z * Try:
		2024-03-20T14:53:51.8840590Z Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
		2024-03-20T14:53:51.8840750Z 
		2024-03-20T14:53:51.8840910Z * Get more help at https://help.gradle.org
		2024-03-20T14:53:51.8840990Z 
		2024-03-20T14:53:51.8841130Z BUILD FAILED in 6m 3s	
